### PR TITLE
fix typo for signature backend

### DIFF
--- a/esig/backends.py
+++ b/esig/backends.py
@@ -166,7 +166,7 @@ if iisignature:
 
 
 
-    BACKENDS["iisignature"] = IIsignatureBackend
+    BACKENDS["iisignature"] = IISignatureBackend
 
 
 # set the default backend


### PR DESCRIPTION
Correction on the capitalization for "signature"