### PR TITLE
Fix numpy build dependency versioning

### DIFF
--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -34,7 +34,7 @@ pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
 $pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'
+$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -33,12 +33,12 @@ mkdir $TMPDIR
 pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
-$pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
+#$pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
 #$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 
 # Try oldest-supported-numpy package
 # https://numpy.org/devdocs/user/depending_on_numpy.html
-$pyexe -m pip install oldest-supported-numpy
+#$pyexe -m pip install oldest-supported-numpy
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -34,7 +34,11 @@ pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
 $pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
+#$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
+
+# Try oldest-supported-numpy package
+# https://numpy.org/devdocs/user/depending_on_numpy.html
+$py_exe -m pip install oldest-supported-numpy
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -33,7 +33,7 @@ mkdir $TMPDIR
 pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
-#$pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
+$pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
 #$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 
 # Try oldest-supported-numpy package

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -34,7 +34,7 @@ pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
 $pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install  --only-binary :all: 'numpy>=1.7.0'
+$pyexe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -34,7 +34,7 @@ pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
 $pyexe -m pip install wheel==0.34.2 # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install -U numpy
+$pyexe -m pip install -U numpy==1.7.0
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -38,7 +38,7 @@ $pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditw
 
 # Try oldest-supported-numpy package
 # https://numpy.org/devdocs/user/depending_on_numpy.html
-$py_exe -m pip install oldest-supported-numpy
+$pyexe -m pip install oldest-supported-numpy
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -33,8 +33,8 @@ mkdir $TMPDIR
 pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
-$pyexe -m pip install wheel==0.34.2 # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install -U numpy==1.7.0
+$pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
+$pyexe -m pip install  --only-binary :all: 'numpy==1.7.0'
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/Linux/linux_wheel_builder.sh
+++ b/build/Linux/linux_wheel_builder.sh
@@ -34,7 +34,7 @@ pyexe=/opt/python/$py/bin/python
 ls -la /opt/python # see what Python versions there are
 $pyexe -m pip install -U pip virtualenv
 $pyexe -m pip install -U 'wheel>=0.34.2' # need at least this version for auditwheel 3.1.1 (Python 3.7)
-$pyexe -m pip install  --only-binary :all: 'numpy==1.7.0'
+$pyexe -m pip install  --only-binary :all: 'numpy>=1.7.0'
 
 # recombine build step will have left library here
 recombine_install_dir=${HOME}/lyonstech

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,7 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install  --only-binary :all: 'numpy>=1.7.0'
+pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,7 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install numpy==1.7.0
+pip install  --only-binary :all: numpy==1.7.0
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -26,7 +26,7 @@ pyenv activate esig_build_env-$p
 
 # install python dependencies
 pip install --upgrade pip
-#pip install --upgrade wheel
+pip install --upgrade wheel
 
 #pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 # Try oldest-supported-numpy package

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,12 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
+
+#pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
+# Try oldest-supported-numpy package
+# https://numpy.org/devdocs/user/depending_on_numpy.html
+pip install oldest-supported-numpy
+
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,7 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'
+pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,7 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install  --only-binary :all: numpy==1.7.0
+pip install  --only-binary :all: 'numpy>=1.7.0'
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -27,7 +27,7 @@ pyenv activate esig_build_env-$p
 # install python dependencies
 pip install --upgrade pip
 pip install --upgrade wheel
-pip install --upgrade numpy
+pip install numpy==1.7.0
 pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -33,7 +33,7 @@ pip install --upgrade wheel
 # https://numpy.org/devdocs/user/depending_on_numpy.html
 #pip install oldest-supported-numpy
 
-#pip install --upgrade delocate
+pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder
     pip wheel -w OSX/$TMPDIR ..

--- a/build/OSX/mac_wheel_builder.sh
+++ b/build/OSX/mac_wheel_builder.sh
@@ -26,14 +26,14 @@ pyenv activate esig_build_env-$p
 
 # install python dependencies
 pip install --upgrade pip
-pip install --upgrade wheel
+#pip install --upgrade wheel
 
 #pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'
 # Try oldest-supported-numpy package
 # https://numpy.org/devdocs/user/depending_on_numpy.html
-pip install oldest-supported-numpy
+#pip install oldest-supported-numpy
 
-pip install --upgrade delocate
+#pip install --upgrade delocate
 # build the wheel
 pushd .. # circular file path if run from OSX folder
     pip wheel -w OSX/$TMPDIR ..

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,11 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'"
+#Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'"
+# Try oldest-supported-numpy package
+# https://numpy.org/devdocs/user/depending_on_numpy.html
+Invoke-Expression "$py_exe -m pip install oldest-supported-numpy"
+
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,7 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install  --only-binary :all: 'numpy>=1.7.0'"
+Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'"
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -63,12 +63,12 @@ echo (Invoke-Expression "$py_exe --version")
 #Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'"
 # Try oldest-supported-numpy package
 # https://numpy.org/devdocs/user/depending_on_numpy.html
-Invoke-Expression "$py_exe -m pip install oldest-supported-numpy"
+#Invoke-Expression "$py_exe -m pip install oldest-supported-numpy"
 
-Invoke-Expression "$py_exe -m pip install wheel"
-Invoke-Expression "$py_exe -m pip install delocate"
-Invoke-Expression "$py_exe -m pip install --upgrade setuptools"
-Invoke-Expression "$py_exe -m pip install --upgrade pip"
+#Invoke-Expression "$py_exe -m pip install wheel"
+#Invoke-Expression "$py_exe -m pip install delocate"
+#Invoke-Expression "$py_exe -m pip install --upgrade setuptools"
+#Invoke-Expression "$py_exe -m pip install --upgrade pip"
 Invoke-Expression "$py_exe -m pip install virtualenv"
 
 # build the wheel

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,7 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install numpy==1.7.0"
+Invoke-Expression "$py_exe -m pip install  --only-binary :all: numpy==1.7.0"
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,7 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install numpy"
+Invoke-Expression "$py_exe -m pip install numpy==1.7.0"
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -65,7 +65,7 @@ echo (Invoke-Expression "$py_exe --version")
 # https://numpy.org/devdocs/user/depending_on_numpy.html
 #Invoke-Expression "$py_exe -m pip install oldest-supported-numpy"
 
-#Invoke-Expression "$py_exe -m pip install wheel"
+Invoke-Expression "$py_exe -m pip install wheel"
 #Invoke-Expression "$py_exe -m pip install delocate"
 #Invoke-Expression "$py_exe -m pip install --upgrade setuptools"
 #Invoke-Expression "$py_exe -m pip install --upgrade pip"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,7 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.7.0'"
+Invoke-Expression "$py_exe -m pip install --no-cache-dir --only-binary :all: 'numpy>=1.17.0'"
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -60,7 +60,7 @@ $py_exe=$py_install_dir + "\python.exe"
 echo $py_exe
 echo (Invoke-Expression "$py_exe --version")
 
-Invoke-Expression "$py_exe -m pip install  --only-binary :all: numpy==1.7.0"
+Invoke-Expression "$py_exe -m pip install  --only-binary :all: 'numpy>=1.7.0'"
 Invoke-Expression "$py_exe -m pip install wheel"
 Invoke-Expression "$py_exe -m pip install delocate"
 Invoke-Expression "$py_exe -m pip install --upgrade setuptools"

--- a/build/Windows/build-wheel.ps1
+++ b/build/Windows/build-wheel.ps1
@@ -67,8 +67,8 @@ echo (Invoke-Expression "$py_exe --version")
 
 Invoke-Expression "$py_exe -m pip install wheel"
 #Invoke-Expression "$py_exe -m pip install delocate"
-#Invoke-Expression "$py_exe -m pip install --upgrade setuptools"
-#Invoke-Expression "$py_exe -m pip install --upgrade pip"
+Invoke-Expression "$py_exe -m pip install --upgrade setuptools"
+Invoke-Expression "$py_exe -m pip install --upgrade pip"
 Invoke-Expression "$py_exe -m pip install virtualenv"
 
 # build the wheel

--- a/setup.py
+++ b/setup.py
@@ -137,12 +137,6 @@ setup(
         # Get the oldest version of Numpy that is supported on each platform
         # This is only for the build phase.
         "oldest-supported-numpy",
-
-        # Needs at least version 0.34.2 for auditwheel
-        "wheel>=0.34.2",
-
-        # On MacOS we need the delocate package to perform the same work as auditwheel
-        "delocate>=0.8.2;platform_system=='darwin'"
     ],
     tests_require=['numpy>=1.7'],
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -108,7 +108,6 @@ if not configuration.no_recombine and configuration.platform == helpers.PLATFORM
     # not sure why this is needed, and if it is, why package_data also needs to mention them
     eager_resources += ["libiomp5md.dll", "recombine.dll"]
 
-
 setup(
     name='esig',
     version=configuration.esig_version,
@@ -134,7 +133,17 @@ setup(
     ext_modules=[esig_extension],
 
     install_requires=['numpy>=1.7'],
-    setup_requires=['numpy>=1.7'],
+    setup_requires=[
+        # Get the oldest version of Numpy that is supported on each platform
+        # This is only for the build phase.
+        "oldest-supported-numpy",
+
+        # Needs at least version 0.34.2 for auditwheel
+        "wheel>=0.34.2",
+
+        # On MacOS we need the delocate package to perform the same work as auditwheel
+        "delocate>=0.8.2;platform_system=='darwin'"
+    ],
     tests_require=['numpy>=1.7'],
     extras_require=extras_require,
 
@@ -154,3 +163,4 @@ setup(
         'build_ext': BuildExtensionCommand,
     }
 )
+


### PR DESCRIPTION
Currently the build system uses the most recent version of numpy to build esig, which results in backwards incompatible module. To fix this, we need to build esig with the oldest version of numpy for each platform and Python version.

Closes #110 