### PR TITLE
Added support and tests for multithreading

### DIFF
--- a/esig/backends.py
+++ b/esig/backends.py
@@ -24,7 +24,8 @@ except ImportError:
 
 BACKENDS = {}
 
-
+_BACKEND_LOCK = threading.RLock()
+_BACKEND_DEFAULT = None
 _BACKEND_CONTAINER = threading.local()
 
 
@@ -32,6 +33,10 @@ def get_backend():
     """
     Get the current global backend used for computing signatures.
     """
+    global _BACKEND_CONTAINER
+    if not hasattr(_BACKEND_CONTAINER, "context"):
+        with _BACKEND_LOCK:
+            _BACKEND_CONTAINER.context = _BACKEND_DEFAULT()
     return _BACKEND_CONTAINER.context
 
 
@@ -49,6 +54,15 @@ def set_backend(cls_or_name):
         _BACKEND_CONTAINER.context = cls_or_name()
     else:
         raise TypeError("Backend must be a subclass of the BackendBase class or str")
+
+
+def set_default_backend(cls):
+    """
+    Set the default backend across all threads.
+    :param cls: Backend class to use.
+    """
+    with _BACKEND_LOCK:
+        _BACKEND_DEFAULT = cls
 
 
 def list_backends():
@@ -170,4 +184,4 @@ if iisignature:
 
 
 # set the default backend
-set_backend(LibalgebraBackend)
+_BACKEND_DEFAULT = LibalgebraBackend

--- a/esig/tests/test_multithreading.py
+++ b/esig/tests/test_multithreading.py
@@ -1,0 +1,52 @@
+import unittest
+import concurrent.futures
+from concurrent.futures import ThreadPoolExecutor
+import numpy as np
+
+import esig
+
+from .test_package_interface import ArrayTestCase
+
+
+class TestMultiThreadingCalculations(ArrayTestCase):
+
+    def setUp(self):
+        rng = np.random.Generator(np.random.MT19937(12345))
+        self.length = 100
+        self.width = 5
+        self.depth = 3
+        self.data = rng.uniform(-4, 4, size=(self.length, self.width))
+
+    @staticmethod
+    def make_function(r, func):
+        def wrap(data, depth):
+            r = func(data, depth)
+        return wrap
+
+    def test_signature_parallel(self):
+
+        with ThreadPoolExecutor(2) as pool:
+            f1 = pool.submit(esig.stream2sig, self.data, self.depth)
+            f2 = pool.submit(esig.stream2sig, self.data, self.depth)
+            done, not_done = concurrent.futures.wait((f1, f2))
+
+        self.assertFalse(not_done)
+        self.assertEqual(len(done), 2)
+
+        self.assert_allclose(f1.result(), f2.result())
+
+    def test_log_signature_parallel(self):
+
+        with ThreadPoolExecutor(2) as pool:
+            f1 = pool.submit(esig.stream2logsig, self.data, self.depth)
+            f2 = pool.submit(esig.stream2logsig, self.data, self.depth)
+            done, not_done = concurrent.futures.wait((f1, f2))
+
+        self.assertFalse(not_done)
+        self.assertEqual(len(done), 2)
+
+        self.assert_allclose(f1.result(), f2.result())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/esig/tests/test_multithreading.py
+++ b/esig/tests/test_multithreading.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import esig
 
-from .test_package_interface import ArrayTestCase
+from esig.tests.test_package_interface import ArrayTestCase
 
 
 class TestMultiThreadingCalculations(ArrayTestCase):

--- a/src/ToSig.cpp
+++ b/src/ToSig.cpp
@@ -255,10 +255,12 @@ namespace {
 		typedef alg::lie<S, Q, WIDTH, DEPTH> LIE;
 		typedef alg::maps<S, Q, WIDTH, DEPTH> MAPS;
 		typedef alg::cbh<S, Q, WIDTH, DEPTH> CBH;
+		Py_BEGIN_ALLOW_THREADS;
 		LIE logans = GetLogSignature<LIE, CBH, WIDTH>(stream);
 		MAPS maps;
 		TENSOR signature = exp(maps.l2t(logans));
 		unpack_tensor_to_SNK<S, TENSOR, WIDTH, DEPTH>(signature, snk);
+		Py_END_ALLOW_THREADS;
 		return true;
 	}
 
@@ -322,8 +324,10 @@ namespace {
 	{
 		typedef alg::lie<S, Q, WIDTH, DEPTH> LIE;
 		typedef alg::cbh<S, Q, WIDTH, DEPTH> CBH;
+		Py_BEGIN_ALLOW_THREADS;
 		LIE logans = GetLogSignature<LIE, CBH, WIDTH>(stream);
 		unpack_lie_to_SNK<S, LIE, WIDTH, DEPTH>(logans, snk);
+		Py_END_ALLOW_THREADS;
 		return true;
 	}
 


### PR DESCRIPTION
I've added code to release the GIL during signature/log-signature calculations to allow multiple threads to run simultaneously. I've also added some tests that perform concurrent calculations to make sure no errors occur.